### PR TITLE
Add Option to Print Timestamps for Infinite Cycles

### DIFF
--- a/src/common.cu
+++ b/src/common.cu
@@ -96,6 +96,7 @@ static int streamnull = 0;
 static int timeout = 0;
 static int cudaGraphLaunches = 0;
 static int report_cputime = 0;
+static int report_timestamps = 0;
 static int deviceImpl = 0;
 
 int deviceCtaCount = 16; // Default number of CTAs for device implementation
@@ -646,7 +647,7 @@ testResult_t TimeTest(struct threadArgs* args, ncclDataType_t type, const char* 
       setupArgs(size, type, args);
       char rootName[100];
       sprintf(rootName, "%6i", root);
-      if (run_cycles == 0) {
+      if (run_cycles == 0 && report_timestamps == 1) {
         time_t t;
         struct tm *tm_info;
         char ts[26];
@@ -857,6 +858,7 @@ int main(int argc, char* argv[]) {
     {"timeout", required_argument, 0, 'T'},
     {"cudagraph", required_argument, 0, 'G'},
     {"report_cputime", required_argument, 0, 'C'},
+    {"report_timestamps", required_argument, 0, 'S'},
     {"average", required_argument, 0, 'a'},
     {"local_register", required_argument, 0, 'R'},
     {"cta_policy", required_argument, 0, 'x'},
@@ -868,7 +870,7 @@ int main(int argc, char* argv[]) {
 
   while(1) {
     int c;
-    c = getopt_long(argc, argv, "t:g:b:e:i:f:n:m:w:N:p:c:o:d:r:z:y:T:hG:C:a:R:x:D:V:", longopts, &longindex);
+    c = getopt_long(argc, argv, "t:g:b:e:i:f:n:m:w:N:p:c:o:d:r:z:y:T:hG:C:S:a:R:x:D:V:", longopts, &longindex);
 
     if (c == -1)
       break;
@@ -957,6 +959,9 @@ int main(int argc, char* argv[]) {
       case 'C':
         report_cputime = strtol(optarg, NULL, 0);
         break;
+      case 'S':
+        report_timestamps = strtol(optarg, NULL, 0);
+        break;
       case 'a':
         average = (int)strtol(optarg, NULL, 0);
         break;
@@ -1035,6 +1040,7 @@ int main(int argc, char* argv[]) {
             "[-T,--timeout <time in seconds>] \n\t"
             "[-G,--cudagraph <num graph launches>] \n\t"
             "[-C,--report_cputime <0/1>] \n\t"
+            "[-S,--report_timestamps <0/1> report timestamps (default 0; requires -N 0)] \n\t"
             "[-a,--average <0/1/2/3> report average iteration time <0=RANK0/1=AVG/2=MIN/3=MAX>] \n\t"
             "[-R,--local_register <0/1/2> enable local (1) or symmetric (2) buffer registration on send/recv buffers (default: disable (0))] \n\t"
             "[-x,--cta_policy <0/1/2> set CTA policy (NCCL_CTA_POLICY_DEFAULT (0), NCCL_CTA_POLICY_EFFICIENCY (1), NCCL_CTA_POLICY_ZERO (2)) (default: do not set)] \n\t"

--- a/src/common.cu
+++ b/src/common.cu
@@ -655,7 +655,7 @@ testResult_t TimeTest(struct threadArgs* args, ncclDataType_t type, const char* 
         time(&t);
         tm_info = localtime(&t);
         strftime(ts, 26, "%Y-%m-%d-%H-%M-%S", tm_info);
-        PRINT("%s %12li  %12li  %8s  %6s  %6s", ts, max(args->sendBytes, args->expectedBytes), args->nbytes / wordSize(type), typeName, opName, rootName);
+        PRINT("%21s %12li  %12li  %8s  %6s  %6s", ts, max(args->sendBytes, args->expectedBytes), args->nbytes / wordSize(type), typeName, opName, rootName);
       }
       else {
         PRINT("%12li  %12li  %8s  %6s  %6s", max(args->sendBytes, args->expectedBytes), args->nbytes / wordSize(type), typeName, opName, rootName);
@@ -1364,13 +1364,18 @@ testResult_t run() {
 
   fflush(stdout);
 
+  int tsPad  = report_timestamps ? 19 : 0;
+  int sizePad = report_timestamps ? 13 : 10;
+  const char* tsLbl  = report_timestamps ? "timestamp" : "";
+  const char* tsFmt = report_timestamps ? "%Y-%m-%d-%H-%M-%S" : "";
   const char* timeStr = report_cputime ? "cputime" : "time";
   PRINT("#\n");
-  PRINT("# %10s  %12s  %8s  %6s  %6s           out-of-place                       in-place          \n", "", "", "", "", "");
-  PRINT("# %10s  %12s  %8s  %6s  %6s  %7s  %6s  %6s %6s  %7s  %6s  %6s %6s\n", "size", "count", "type", "redop", "root",
+  PRINT("# %*s%*s  %12s  %8s  %6s  %6s           out-of-place                       in-place          \n", tsPad, "", sizePad, "", "", "", "", "");
+  PRINT("# %*s%*s  %12s  %8s  %6s  %6s  %7s  %6s  %6s %6s  %7s  %6s  %6s %6s\n", tsPad, tsLbl, sizePad, "size", "count", "type", "redop", "root",
       timeStr, "algbw", "busbw", "#wrong", timeStr, "algbw", "busbw", "#wrong");
-  PRINT("# %10s  %12s  %8s  %6s  %6s  %7s  %6s  %6s  %5s  %7s  %6s  %6s  %5s\n", "(B)", "(elements)", "", "", "",
+  PRINT("# %*s%*s  %12s  %8s  %6s  %6s  %7s  %6s  %6s  %5s  %7s  %6s  %6s  %5s\n", tsPad, tsFmt, sizePad, "(B)", "(elements)", "", "", "",
       "(us)", "(GB/s)", "(GB/s)", "", "(us)", "(GB/s)", "(GB/s)", "");
+
 
   struct testThread threads[nThreads];
   memset(threads, 0, sizeof(struct testThread)*nThreads);

--- a/src/common.cu
+++ b/src/common.cu
@@ -646,7 +646,19 @@ testResult_t TimeTest(struct threadArgs* args, ncclDataType_t type, const char* 
       setupArgs(size, type, args);
       char rootName[100];
       sprintf(rootName, "%6i", root);
-      PRINT("%12li  %12li  %8s  %6s  %6s", max(args->sendBytes, args->expectedBytes), args->nbytes / wordSize(type), typeName, opName, rootName);
+      if (run_cycles == 0) {
+        time_t t;
+        struct tm *tm_info;
+        char ts[26];
+
+        time(&t);
+        tm_info = localtime(&t);
+        strftime(ts, 26, "%Y-%m-%d-%H-%M-%S", tm_info);
+        PRINT("%s %12li  %12li  %8s  %6s  %6s", ts, max(args->sendBytes, args->expectedBytes), args->nbytes / wordSize(type), typeName, opName, rootName);
+      }
+      else {
+        PRINT("%12li  %12li  %8s  %6s  %6s", max(args->sendBytes, args->expectedBytes), args->nbytes / wordSize(type), typeName, opName, rootName);
+      }
       TESTCHECK(BenchTime(args, type, op, root, 0));
       TESTCHECK(BenchTime(args, type, op, root, 1));
       PRINT("\n");


### PR DESCRIPTION
Add a new argument `-S,--report_timestamps <0/1> (default 0)` to print timestamps when infinite cycles `-N, --run_cycles = 0` is specified.

Examples:
`-S = 1`, infinite cycles with timestamp reporting
```shell
mpirun --timeout 600 -np 4 --map-by ppr:4:node -x LD_LIBRARY_PATH -mca coll_hcoll_enable 0 --mca btl tcp,vader,self --mca pml ob1 --mca btl_tcp_if_include enP22p1s0f1 -x UCX_NET_DEVICES=enP22p1s0f1 -x NCCL_SOCKET_IFNAME=enP22p1s0f1 -x NCCL_DEBUG=WARN -x NCCL_IB_DISABLE=1 -x NCCL_MNNVL_ENABLE=1 -x NCCL_NVLS_ENABLE=1 /home/azhpcuser/yakov/nccl-tests/build/alltoall_perf -f 2 -g1 -b16G -e 16G -c 1 -R 1 -N 0 -S 1
# Collective test starting: alltoall_perf
# nThread 1 nGpus 1 minBytes 17179869184 maxBytes 17179869184 step: 2(factor) warmup iters: 1 iters: 20 agg iters: 1 validation: 1 graph: 0
#
# Using devices
#  Rank  0 Group  0 Pid  54455 on DSM121082602029 device  0 [0008:06:00] NVIDIA GB200
#  Rank  1 Group  0 Pid  54456 on DSM121082602029 device  1 [0009:06:00] NVIDIA GB200
#  Rank  2 Group  0 Pid  54458 on DSM121082602029 device  2 [0018:06:00] NVIDIA GB200
#  Rank  3 Group  0 Pid  54462 on DSM121082602029 device  3 [0019:06:00] NVIDIA GB200
NCCL version 2.28.3+cuda13.0
#
#                                                                                    out-of-place                       in-place
#           timestamp         size         count      type   redop    root     time   algbw   busbw #wrong     time   algbw   busbw #wrong
#   %Y-%m-%d-%H-%M-%S          (B)    (elements)                               (us)  (GB/s)  (GB/s)            (us)  (GB/s)  (GB/s)
  2025-10-08-04-12-19  17179869184    1073741824     float    none      -1    20655  831.76  623.82      0    20977  818.98  614.24    N/A
  2025-10-08-04-12-20  17179869184    1073741824     float    none      -1    20677  830.87  623.15      0    21030  816.94  612.70    N/A
  2025-10-08-04-12-22  17179869184    1073741824     float    none      -1    20748  828.04  621.03      0    21025  817.13  612.85    N/A
  2025-10-08-04-12-23  17179869184    1073741824     float    none      -1    20760  827.54  620.66      0    21001  818.05  613.54    N/A
  2025-10-08-04-12-24  17179869184    1073741824     float    none      -1    20698  830.02  622.52      0    21001  818.03  613.53    N/A
```

`-S = 0`, infinite cycles without timestamp reporting (explicit)
```shell
mpirun --timeout 600 -np 4 --map-by ppr:4:node -x LD_LIBRARY_PATH -mca coll_hcoll_enable 0 --mca btl tcp,vader,self --mca pml ob1 --mca btl_tcp_if_include enP22p1s0f1 -x UCX_NET_DEVICES=enP22p1s0f1 -x NCCL_SOCKET_IFNAME=enP2
2p1s0f1 -x NCCL_DEBUG=WARN -x NCCL_IB_DISABLE=1 -x NCCL_MNNVL_ENABLE=1 -x NCCL_NVLS_ENABLE=1 /home/azhpcuser/yakov/nccl-tests/build/alltoall_perf -f 2 -g1 -b16G -e 16G -c 1 -R 1 -N 0 -S 0
# Collective test starting: alltoall_perf
# nThread 1 nGpus 1 minBytes 17179869184 maxBytes 17179869184 step: 2(factor) warmup iters: 1 iters: 20 agg iters: 1 validation: 1 graph: 0
#
# Using devices
#  Rank  0 Group  0 Pid  81201 on DSM121082602029 device  0 [0008:06:00] NVIDIA GB200
#  Rank  1 Group  0 Pid  81202 on DSM121082602029 device  1 [0009:06:00] NVIDIA GB200
#  Rank  2 Group  0 Pid  81204 on DSM121082602029 device  2 [0018:06:00] NVIDIA GB200
#  Rank  3 Group  0 Pid  81208 on DSM121082602029 device  3 [0019:06:00] NVIDIA GB200
NCCL version 2.28.3+cuda13.0
#
#                                                              out-of-place                       in-place
#       size         count      type   redop    root     time   algbw   busbw #wrong     time   algbw   busbw #wrong
#        (B)    (elements)                               (us)  (GB/s)  (GB/s)            (us)  (GB/s)  (GB/s)
 17179869184    1073741824     float    none      -1    20725  828.93  621.70      0    20956  819.81  614.85    N/A
 17179869184    1073741824     float    none      -1    20756  827.70  620.77      0    21003  817.99  613.49    N/A
 17179869184    1073741824     float    none      -1    20715  829.35  622.01      0    20982  818.80  614.10    N/A
 17179869184    1073741824     float    none      -1    20734  828.57  621.43      0    21005  817.89  613.41    N/A
 17179869184    1073741824     float    none      -1    20676  830.92  623.19      0    21035  816.74  612.55    N/A
```

Infinite cycles default behavior
```shell
mpirun --timeout 600 -np 4 --map-by ppr:4:node -x LD_LIBRARY_PATH -mca coll_hcoll_enable 0 --mca btl tcp,vader,self --mca pml ob1 --mca btl_tcp_if_include enP22p1s0f1 -x UCX_NET_DEVICES=enP22p1s0f1 -x NCCL_SOCKET_IFNAME=enP22p1s0f1 -x NCCL_DEBUG=WARN -x NCCL_IB_DISABLE=1 -x NCCL_MNNVL_ENABLE=1 -x NCCL_NVLS_ENABLE=1 /home/azhpcuser/yakov/nccl-tests/build/alltoall_perf -f 2 -g1 -b16G -e 16G -c 1 -R 1 -N 0
# Collective test starting: alltoall_perf
# nThread 1 nGpus 1 minBytes 17179869184 maxBytes 17179869184 step: 2(factor) warmup iters: 1 iters: 20 agg iters: 1 validation: 1 graph: 0
#
# Using devices
#  Rank  0 Group  0 Pid  81567 on DSM121082602029 device  0 [0008:06:00] NVIDIA GB200
#  Rank  1 Group  0 Pid  81568 on DSM121082602029 device  1 [0009:06:00] NVIDIA GB200
#  Rank  2 Group  0 Pid  81571 on DSM121082602029 device  2 [0018:06:00] NVIDIA GB200
#  Rank  3 Group  0 Pid  81573 on DSM121082602029 device  3 [0019:06:00] NVIDIA GB200
NCCL version 2.28.3+cuda13.0
#
#                                                              out-of-place                       in-place
#       size         count      type   redop    root     time   algbw   busbw #wrong     time   algbw   busbw #wrong
#        (B)    (elements)                               (us)  (GB/s)  (GB/s)            (us)  (GB/s)  (GB/s)
 17179869184    1073741824     float    none      -1    20722  829.08  621.81      0    20988  818.54  613.91    N/A
 17179869184    1073741824     float    none      -1    20683  830.61  622.96      0    21080  814.97  611.23    N/A
 17179869184    1073741824     float    none      -1    20656  831.72  623.79      0    20999  818.12  613.59    N/A
 17179869184    1073741824     float    none      -1    20676  830.92  623.19      0    21061  815.71  611.78    N/A
 17179869184    1073741824     float    none      -1    20649  832.01  624.01      0    20937  820.55  615.41    N/A
```

"N" cycles
```shell
mpirun --timeout 600 -np 4 --map-by ppr:4:node -x LD_LIBRARY_PATH -mca coll_hcoll_enable 0 --mca btl tcp,vader,self --mca pml ob1 --mca btl_tcp_if_include enP22p1s0f1 -x UCX_NET_DEVICES=enP22p1s0f1 -x NCCL_SOCKET_IFNAME=enP22p1s0f1 -x NCCL_DEBUG=WARN -x NCCL_IB_DISABLE=1 -x NCCL_MNNVL_ENABLE=1 -x NCCL_NVLS_ENABLE=1 /home/azhpcuser/yakov/nccl-tests/build/alltoall_perf -f 2 -g1 -b16G -e 16G -c 1 -R 1 -N 5
# Collective test starting: alltoall_perf
# nThread 1 nGpus 1 minBytes 17179869184 maxBytes 17179869184 step: 2(factor) warmup iters: 1 iters: 20 agg iters: 1 validation: 1 graph: 0
#
# Using devices
#  Rank  0 Group  0 Pid  81813 on DSM121082602029 device  0 [0008:06:00] NVIDIA GB200
#  Rank  1 Group  0 Pid  81814 on DSM121082602029 device  1 [0009:06:00] NVIDIA GB200
#  Rank  2 Group  0 Pid  81817 on DSM121082602029 device  2 [0018:06:00] NVIDIA GB200
#  Rank  3 Group  0 Pid  81818 on DSM121082602029 device  3 [0019:06:00] NVIDIA GB200
NCCL version 2.28.3+cuda13.0
#
#                                                              out-of-place                       in-place
#       size         count      type   redop    root     time   algbw   busbw #wrong     time   algbw   busbw #wrong
#        (B)    (elements)                               (us)  (GB/s)  (GB/s)            (us)  (GB/s)  (GB/s)
 17179869184    1073741824     float    none      -1    20691  830.29  622.72      0    21036  816.69  612.52    N/A
 17179869184    1073741824     float    none      -1    20691  830.29  622.72      0    21054  815.99  611.99    N/A
 17179869184    1073741824     float    none      -1    20729  828.79  621.59      0    21010  817.72  613.29    N/A
 17179869184    1073741824     float    none      -1    20700  829.94  622.46      0    20984  818.71  614.04    N/A
 17179869184    1073741824     float    none      -1    20747  828.05  621.04      0    21026  817.07  612.80    N/A
# Out of bounds values : 0 OK
# Avg bus bandwidth    : 617.517
#
# Collective test concluded: alltoall_perf
```
